### PR TITLE
Upgrade to postcss 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,11 +64,11 @@ module.exports = function(options) {
       // optionally remove `--*` properties from the rule
       if (!preserve) {
         for (var i = toRemove.length - 1; i >= 0; i--) {
-          rule.childs.splice(toRemove[i], 1)
+          rule.nodes.splice(toRemove[i], 1)
         }
 
         // remove empty :root {}
-        if (rule.childs.length === 0) {
+        if (rule.nodes.length === 0) {
           rule.removeSelf()
         }
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "jscs": "^1.6.2",
     "jshint": "^2.5.6",
-    "postcss": "^3.0.0",
+    "postcss": "^4.0.0",
     "tape": "^3.0.0"
   },
   "scripts": {


### PR DESCRIPTION
All that I did was change `childs` to `nodes` (per https://github.com/postcss/postcss/blob/master/ChangeLog.md#40-duke-flauros), and the existing tests passed. I did not further analyze the upgrade, just looked for necessary syntax changes with the simple goal of making the existing tests pass. If you think that's good enough, then it's a pretty simple upgrade.