### PR TITLE
Add `preserve: "computed"` and `append` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ module.exports = function(options) {
       }
     })
     var append = options.append
-    var preserve = append || options.preserve
+    var preserve = options.preserve
     var map = {}
     var importantMap = {}
 
@@ -193,7 +193,7 @@ module.exports = function(options) {
       }
     })
 
-    if (append) {
+    if (preserve) {
       Object.keys(map).forEach(function(name) {
         var variable = map[name]
         if (!variable.resolved) {
@@ -219,12 +219,12 @@ module.exports = function(options) {
         })
       }, decl.source)
 
-      if (!preserve) {
+      if (!preserve || preserve === "computed") {
         decl.removeSelf()
       }
     })
 
-    if (append) {
+    if (preserve && append) {
       var names = Object.keys(map)
       if (names.length) {
         var container = postcss.rule({

--- a/index.js
+++ b/index.js
@@ -119,16 +119,13 @@ function resolveValue(value, variables, source) {
 module.exports = function(options) {
   return function(style) {
     options = options || {}
-    var userVariables = options.variables || {}
-    var variables =
-      Object.keys(userVariables)
-        .reduce(function(acc, key) {
-          if (key.indexOf("--") !== 0) {
-            acc["--" + key] = userVariables[key]
-          }
-          acc[key] = userVariables[key]
-          return acc
-        }, {})
+    var variables = options.variables || {}
+    Object.keys(variables).forEach(function(name) {
+      if (name.slice(0, 2) !== "--") {
+        variables["--" + name] = variables[name]
+        delete variables[name]
+      }
+    })
     var preserve = (options.preserve === true ? true : false)
     var map = {}
     var importantMap = {}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "dependencies": {
     "balanced-match": "~0.1.0",
+    "postcss": "^4.1.4",
     "postcss-message-helpers": "^2.0.0"
   },
   "devDependencies": {

--- a/test/fixtures/append.css
+++ b/test/fixtures/append.css
@@ -1,0 +1,3 @@
+div {
+	p: var(--test-one);
+}

--- a/test/fixtures/append.expected.css
+++ b/test/fixtures/append.expected.css
@@ -1,8 +1,8 @@
 div {
 	p: js-one;
-	p: var(--test-one);
 }
 :root {
 	--test-one: js-one;
 	--test-two: js-two;
+	--test-three: js-one js-two;
 }

--- a/test/fixtures/append.expected.css
+++ b/test/fixtures/append.expected.css
@@ -1,0 +1,8 @@
+div {
+	p: js-one;
+	p: var(--test-one);
+}
+:root {
+	--test-one: js-one;
+	--test-two: js-two;
+}

--- a/test/fixtures/preserve-computed.css
+++ b/test/fixtures/preserve-computed.css
@@ -1,0 +1,21 @@
+:root {
+  --color-one: red;
+  --color-two: blue;
+  --color-three: var(--color-two);
+}
+
+.atthebeginning {
+  color: var(--color-one);
+  prop: after;
+}
+
+.attheend {
+  prop: before;
+  color: var(--color-two);
+}
+
+.surrounded {
+  prop: before;
+  color: var(--undefined-color, green);
+  otherprop: after;
+}

--- a/test/fixtures/preserve-computed.expected.css
+++ b/test/fixtures/preserve-computed.expected.css
@@ -1,0 +1,21 @@
+:root {
+  --color-one: red;
+  --color-two: blue;
+  --color-three: blue;
+}
+
+.atthebeginning {
+  color: red;
+  prop: after;
+}
+
+.attheend {
+  prop: before;
+  color: blue;
+}
+
+.surrounded {
+  prop: before;
+  color: green;
+  otherprop: after;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -107,6 +107,11 @@ test("preserves variables when `preserve` is `true`", function(t) {
   t.end()
 })
 
+test("preserves computed value when `preserve` is `\"computed\"`", function(t) {
+  compareFixtures(t, "preserve-computed", {preserve: "computed"})
+  t.end()
+})
+
 test("circular variable references", function(t) {
   compareFixtures(t, "self-reference")
   compareFixtures(t, "circular-reference")
@@ -124,8 +129,10 @@ test("append variables", function(t) {
     variables: {
       "--test-one": "js-one",
       "test-two": "js-two",
+      "test-three": "var(--test-one, one) var(--test-two, two)",
     },
     append: true,
+    preserve: "computed",
   })
   t.end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -118,3 +118,14 @@ test("circular variable references with fallback", function(t) {
   compareFixtures(t, "self-reference-double-fallback")
   t.end()
 })
+
+test("append variables", function(t) {
+  compareFixtures(t, "append", {
+    variables: {
+      "--test-one": "js-one",
+      "test-two": "js-two",
+    },
+    append: true,
+  })
+  t.end()
+})


### PR DESCRIPTION
After something contemplation, I decide to go with `preserve: "computed"`

`preserve: "computed"` only preserves the computed custom properties definitions and usages. There are no `preserve: "specified"` and `preserve: "all"`.

`append` appends the js defined custom properties to the root node, so the final computed values can be picked up by cssnext (for the `extract` option)