### PR TITLE
Convert js defined variables to strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ module.exports = postcss.plugin("postcss-custom-properties", function(options) {
         if (name.slice(0, 2) !== "--") {
           name = "--" + name
         }
-        variables[name] = val
+        variables[name] = String(val)
       })
     }
     var strict = options.strict

--- a/test/fixtures/js-defined.css
+++ b/test/fixtures/js-defined.css
@@ -9,4 +9,5 @@ div {
   p: var(--test-three);
   p: var(--test-varception);
   p: var(--test-jsception);
+  p: var(--test-num);
 }

--- a/test/fixtures/js-defined.expected.css
+++ b/test/fixtures/js-defined.expected.css
@@ -4,4 +4,5 @@ div {
   p: js-three;
   p: js-one;
   p: js-one;
+  p: 1;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -62,6 +62,7 @@ test("accepts variables defined from JavaScript, and overrides local definitions
       "--test-three": "js-three",
       "--test-varception": "var(--test-one)",
       "--test-jsception": "var(--test-varception)",
+      "--test-num": 1,
     },
   })
   t.end()


### PR DESCRIPTION
Otherwise `value.indexOf` fails