### PR TITLE
Apply warnings configuration to all warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,6 @@ Default: `true`
 Type: `Boolean|Object`
 
 Allows you to enable/disable warnings. If true, will enable all warnings.
-For now, it only allow to disable messages about custom properties definition
-not scoped in a `:root` selector.
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ module.exports = postcss.plugin("postcss-custom-properties", function(options) {
     options.variables = prefixVariables(variables)
   }
 
-  function plugin(style, result) {
+  function plugin(style, _result) {
     var warnings = options.warnings === undefined ? true : options.warnings
     var variables = prefixVariables(options.variables)
     var strict = options.strict === undefined ? true : options.strict
@@ -163,6 +163,11 @@ module.exports = postcss.plugin("postcss-custom-properties", function(options) {
     var preserve = options.preserve
     var map = {}
     var importantMap = {}
+
+    // override the warn function to do nothing if warnings are disabled
+    var result = Object.assign({}, _result, {
+      warn: warnings === true ? _result.warn : function () {}
+    });
 
     // define variables
     style.walkRules(function(rule) {
@@ -177,7 +182,6 @@ module.exports = postcss.plugin("postcss-custom-properties", function(options) {
         rule.each(function(decl) {
           var prop = decl.prop
           if (
-            warnings &&
             prop &&
             prop.indexOf(VAR_PROP_IDENTIFIER) === 0
           ) {

--- a/index.js
+++ b/index.js
@@ -166,8 +166,8 @@ module.exports = postcss.plugin("postcss-custom-properties", function(options) {
 
     // override the warn function to do nothing if warnings are disabled
     var result = Object.assign({}, _result, {
-      warn: warnings === true ? _result.warn : function () {}
-    });
+      warn: warnings === true ? _result.warn : function() {},
+    })
 
     // define variables
     style.walkRules(function(rule) {

--- a/test/index.js
+++ b/test/index.js
@@ -74,7 +74,11 @@ test(
 test(
   "allow hiding undefined var warning",
   function(t) {
-    var result = compareFixtures(t, "substitution-undefined", { warnings: false })
+    var result = compareFixtures(
+      t,
+      "substitution-undefined",
+      {warnings: false}
+    )
     t.equal(
       result.messages.length,
       0,
@@ -217,7 +221,7 @@ test("circular variable references", function(t) {
 
 test("allow hiding circular variable reference warning", function(t) {
   compareFixtures(t, "self-reference")
-  var result = compareFixtures(t, "circular-reference", { warnings: false })
+  var result = compareFixtures(t, "circular-reference", {warnings: false})
   t.equal(
     result.messages.length,
     0,

--- a/test/index.js
+++ b/test/index.js
@@ -71,6 +71,19 @@ test(
   }
 )
 
+test(
+  "allow hiding undefined var warning",
+  function(t) {
+    var result = compareFixtures(t, "substitution-undefined", { warnings: false })
+    t.equal(
+      result.messages.length,
+      0,
+      "should not add warnings if option set to false"
+    )
+    t.end()
+  }
+)
+
 test("substitutes defined variables in `:root` only", function(t) {
   var result = compareFixtures(t, "substitution-defined")
   t.ok(
@@ -80,7 +93,7 @@ test("substitutes defined variables in `:root` only", function(t) {
   t.end()
 })
 
-test("allow to hide warnings", function(t) {
+test("allow hiding non root custom property warning", function(t) {
   var result = compareFixtures(
     t,
     "substitution-defined",
@@ -198,6 +211,17 @@ test("circular variable references", function(t) {
     result.messages[0].text,
     "Circular variable reference: --color",
     "should add a warning for circular reference"
+  )
+  t.end()
+})
+
+test("allow hiding circular variable reference warning", function(t) {
+  compareFixtures(t, "self-reference")
+  var result = compareFixtures(t, "circular-reference", { warnings: false })
+  t.equal(
+    result.messages.length,
+    0,
+    "should not add warnings if option set to false"
   )
   t.end()
 })


### PR DESCRIPTION
Creating a new result object and overriding the warn function seemed easier than passing the warnings configuration setting into the `resolveValue` function :)

I can do it that way if you prefer, though.