### PR TITLE
Add an option to disable the undefined and no fallback variable

### DIFF
--- a/test/fixtures/substitution-undefined-no-warning.css
+++ b/test/fixtures/substitution-undefined-no-warning.css
@@ -1,0 +1,12 @@
+:root {
+  --defined: true
+}
+
+div {
+  color: var(--test);
+  color: var(--test, fallback);
+  background: linear-gradient(var(--a), var(--b));
+  background: linear-gradient(var(--a), var(--b), var(--defined));
+  background: linear-gradient(var(--a), var(--defined) , var(--b));
+  background: linear-gradient(var(--a), var(--defined) , var(--b), var(--defined));
+}

--- a/test/fixtures/substitution-undefined-no-warning.expected.css
+++ b/test/fixtures/substitution-undefined-no-warning.expected.css
@@ -1,0 +1,8 @@
+div {
+  color: var(--test);
+  color: fallback;
+  background: linear-gradient(var(--a), var(--b));
+  background: linear-gradient(var(--a), var(--b), true);
+  background: linear-gradient(var(--a), true , var(--b));
+  background: linear-gradient(var(--a), true , var(--b), true);
+}

--- a/test/index.js
+++ b/test/index.js
@@ -71,6 +71,22 @@ test(
   }
 )
 
+test(
+  "substitutes nothing when a variable function references an undefined var"
+  + " and do not trigger a warning",
+  function(t) {
+    var result = compareFixtures(t, "substitution-undefined-no-warning", {
+      allowEmpty: true,
+    })
+    t.equal(
+      result.messages.length,
+      0,
+      "should not add a warning for undefined variable when warning disabled"
+    )
+    t.end()
+  }
+)
+
 test("substitutes defined variables in `:root` only", function(t) {
   var result = compareFixtures(t, "substitution-defined")
   t.ok(


### PR DESCRIPTION
I need to be able to pre-compile the style of a library of component. But I could not resolve yet all the variable (some customization related variable: colors, font-family...). My user (me in another application) will have to finish the compilations.

So on this pre-compilation time I want to remove the warnings. And later on the final compilation I will let the warning active.