### PR TITLE
Fix README typo regarding `appendVariables` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ variables in your codebase.
 
 Default: `false`
 
-If `preserve` is set to `true` (or `"computed"`), allows you to append your
+If `preserve` is set to `false` (or `"computed"`), allows you to append your
 variables at the end of your CSS.
 
 #### `warnings`


### PR DESCRIPTION
Please correct me if I'm wrong, but I believe the intent of the docs regarding `appendVariables` is to say that if you _aren't_ preserving variables during the build, you can still have them tacked on in the end. If so, this would be an important fix. 