### PR TITLE
Typo in variable name

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ function prefixVariables(variables) {
   const prefixedVariables = {}
 
   if (!variables) {
-    return prefixVariables
+    return prefixedVariables
   }
 
   Object.keys(variables).forEach((name) => {


### PR DESCRIPTION
Should be returning the empty object instead of itself