### PR TITLE
6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 6.3.0 - 2018-02-15
+
+- Fixed: `var()` captures strictly `var()` functions and not `xvar()`, etc
+- Fixed: `var()` better captures whitespace within the function
+- Fixed: comments within declarations using `var()` are now preserved
+- Changed: `preserve` option defaults as `true` to reflect the browser climate
+- Changed: `warnings` option defaults to `false` to reflect the browser climate
+- Updated documentation
+
 # 6.2.0 - 2017-10-06
 
 - Added: `noValueNotifications` option (#71)

--- a/README.md
+++ b/README.md
@@ -1,45 +1,130 @@
-# postcss-custom-properties [![CSS Standard Status](https://jonathantneal.github.io/css-db/badge/css-variables.svg)](https://jonathantneal.github.io/css-db/#css-variables) [![Build Status](https://travis-ci.org/postcss/postcss-custom-properties.svg)](https://travis-ci.org/postcss/postcss-custom-properties)
+# PostCSS Custom Properties [<img src="https://postcss.github.io/postcss/logo.svg" alt="PostCSS Logo" width="90" height="90" align="right">][postcss]
 
-> [PostCSS](https://github.com/postcss/postcss) plugin to transform [W3C CSS Custom Properties for ~~cascading~~ variables](http://www.w3.org/TR/css-variables/) syntax to more compatible CSS.
+[![NPM Version][npm-img]][npm-url]
+[![CSS Standard Status][css-img]][css-url]
+[![Build Status][cli-img]][cli-url]
+[![Gitter Chat][git-img]][git-url]
 
-_Per w3c specifications, the usage of `var()` is limited to property values. Do not expect the plugin to transform `var()` in media queries or in selectors._
+[PostCSS Custom Properties] lets you use CSS Custom Properties in CSS, following
+the [CSS Custom Properties for Cascading Variables] specification.
 
-**N.B.** The transformation _is not complete_ and **cannot be** (dynamic *cascading* variables based on custom properties relies on the DOM tree).
-It currently just aims to provide a future-proof way of using a **limited subset (to `:root` selector)** of the features provided by native CSS custom properties.
-_Since we do not know the DOM in the context of this plugin, we cannot produce safe output_.
-Read [#1](https://github.com/postcss/postcss-custom-properties/issues/1) & [#9](https://github.com/postcss/postcss-custom-properties/issues/9) to know why this limitation exists.
+```css
+:root {
+  --color: red;
+}
 
-_If you are looking for a full support of CSS custom properties, please follow [the opened issue for runtime support](https://github.com/postcss/postcss-custom-properties/issues/32)._
+h1 {
+  color: var(--color);
+}
 
-**N.B.²** If you are wondering why there is a different plugin ([`postcss-css-variables`](https://github.com/MadLittleMods/postcss-css-variables)) that claims to do more than this plugin, be sure to understand the explanation above about limitation. This plugins have a behavior that is not [reflecting the specifications](https://github.com/MadLittleMods/postcss-css-variables/issues/4).
+/* becomes */
 
-_This plugin works great with [postcss-calc](https://github.com/postcss/postcss-calc)._
+:root {
+  --color: red;
+}
 
-## Installation
-
-```console
-$ npm install postcss-custom-properties
+div {
+  color: red;
+  color: var(--color);
+}
 ```
 
 ## Usage
 
-```js
-// dependencies
-var fs = require("fs")
-var postcss = require("postcss")
-var customProperties = require("postcss-custom-properties")
+Add [PostCSS Custom Properties] to your build tool:
 
-// css to be processed
-var css = fs.readFileSync("input.css", "utf8")
-
-// process css using postcss-custom-properties
-var output = postcss()
-  .use(customProperties())
-  .process(css)
-  .css
+```bash
+npm install postcss-custom-properties --save-dev
 ```
 
-Using this `input.css`:
+#### Node
+
+Use [PostCSS Custom Properties] to process your CSS:
+
+```js
+import postCSSCustomProperties from 'postcss-custom-properties';
+
+postCSSCustomProperties.process(YOUR_CSS);
+```
+
+#### PostCSS
+
+Add [PostCSS] to your build tool:
+
+```bash
+npm install postcss --save-dev
+```
+
+Use [PostCSS Custom Properties] as a plugin:
+
+```js
+import postcss from 'gulp-postcss';
+import postCSSCustomProperties from 'postcss-custom-properties';
+
+postcss([
+  postCSSCustomProperties()
+]).process(YOUR_CSS);
+```
+
+#### Gulp
+
+Add [Gulp PostCSS] to your build tool:
+
+```bash
+npm install gulp-postcss --save-dev
+```
+
+Use [PostCSS Custom Properties] in your Gulpfile:
+
+```js
+import postcss from 'gulp-postcss';
+import postCSSCustomProperties from 'postcss-custom-properties';
+
+gulp.task('css', () => gulp.src('./src/*.css').pipe(
+  postcss([
+    postCSSCustomProperties()
+  ])
+).pipe(
+  gulp.dest('.')
+));
+```
+
+#### Grunt
+
+Add [Grunt PostCSS] to your build tool:
+
+```bash
+npm install grunt-postcss --save-dev
+```
+
+Use [PostCSS Custom Properties] in your Gruntfile:
+
+```js
+import postCSSCustomProperties from 'postcss-custom-properties';
+
+grunt.loadNpmTasks('grunt-postcss');
+
+grunt.initConfig({
+  postcss: {
+    options: {
+      use: [
+       postCSSCustomProperties()
+      ]
+    },
+    dist: {
+      src: '*.css'
+    }
+  }
+});
+```
+
+## Options
+
+### strict
+
+The `strict` option determines whether a `var()` function should transform into
+its specified fallback value. By default, the option is `true` because this
+plugin can not verify if the computed `:root` value is valid or not.
 
 ```css
 :root {
@@ -47,128 +132,247 @@ Using this `input.css`:
 }
 
 div {
+  color: var(--color, blue);
+}
+
+/* becomes */
+
+:root {
+  --color: red;
+}
+
+div {
+  color: blue;
+  color: var(--color, blue);
+}
+```
+
+### preserve
+
+The `preserve` option determines how Custom Properties should be preserved. By
+default, this option is truthy and preserves declarations containing `var()`.
+
+```css
+:root {
+  --color: red;
+}
+
+h1 {
+  color: var(--color);
+}
+
+/* becomes */
+
+:root {
+  --color: red;
+}
+
+h1 {
+  color: red;
   color: var(--color);
 }
 ```
 
-you will get:
+The option may also be set to `false`, where Custom Properties and declarations
+containing `var()` will be removed:
+
+```js
+postCSSCustomProperties({
+  variables: {
+    preserve: false
+  }
+})
+```
 
 ```css
-div {
+:root {
+  --color: red;
+}
+
+h1 {
+  color: var(--color);
+}
+
+/* becomes */
+
+h1 {
   color: red;
 }
 ```
 
-You can also compile CSS custom properties with their fallback value.
-
-Using this `input.css`:
-
-```css
-div {
-  color: var(--color, #f00);
-}
-```
-
-you will get:
-
-```css
-div {
-  color: #f00;
-}
-```
-
-Note that plugin returns itself in order to expose a `setVariables` function
-that allow you to programmatically change the variables.
+The option may also be set to `"preserve-computed"`, where Custom Properties
+will remain, but declarations containing `var()` will be removed:
 
 ```js
-var variables = {
-  "--a": "b",
-}
-var plugin = customProperties()
-plugin.setVariables(variables)
-var result = postcss()
-  .use(plugin)
-  .process(input)
+postCSSCustomProperties({
+  variables: {
+    preserve: 'preserve-computed'
+  }
+})
 ```
 
-This might help for dynamic live/hot reloading.
+```css
+:root {
+  --color: red;
+}
 
-Checkout [tests](test) for more.
+h1 {
+  color: var(--color);
+}
 
-### Options
+/* becomes */
 
-#### `strict`
+:root {
+  --color: red;
+}
 
-Default: `true`
+h1 {
+  color: red;
+}
+```
 
-Per specifications, all fallbacks should be added since we can't verify if a
-computed value is valid or not.
-This option allows you to avoid adding too many fallback values in your CSS.
+### variables
 
-#### `preserve`
-
-Default: `false`
-
-Allows you to preserve custom properties & var() usage in output.
+The `variables` option allows you to pass an object of variables into CSS, as if
+they had been specified on `:root`.
 
 ```js
-var out = postcss()
-  .use(customProperties({preserve: true}))
-  .process(css)
-  .css
+postCSSCustomProperties({
+  variables: {
+    color: 'red'
+  }
+})
 ```
 
-You can also set `preserve: "computed"` to get computed resolved custom
-properties in the final output.
-Handy to make them available to your JavaScript.
+```css
+h1 {
+  color: var(--color);
+}
 
-#### `variables`
+/* becomes */
 
-Default: `{}`
+h1 {
+  color: red;
+  color: var(--color);
+}
+```
 
-Allows you to pass an object of variables for `:root`. These definitions will
-override any that exist in the CSS.
-The keys are automatically prefixed with the CSS `--` to make it easier to share
+Note that these definitions will override any that exist in the CSS, and that
+the keys will be automatically prefixed (`--`) to make it easier to share
 variables in your codebase.
 
-#### `appendVariables`
+### appendVariables
 
-Default: `false`
+The `appendVariables` option determines whether Custom Properties will be
+appended to your CSS file. By default, this option is `false`.
 
-If `preserve` is set to `true` (or `"computed"`), allows you to append your
-variables at the end of your CSS.
+If enabled when `preserve` is set to `true` or `"computed"`, this option allows
+you to append your variables at the end of your CSS:
 
-#### `warnings`
+```js
+postCSSCustomProperties({
+  appendVariables: true,
+  variables: {
+    color: 'red'
+  }
+})
+```
 
-Default: `true`
-Type: `Boolean`
+```css
+h1 {
+  color: var(--color);
+}
 
-Allows you to enable/disable warnings. If true, will enable all warnings.
-For now, it only allow to disable messages about custom properties definition
-not scoped in a `:root` selector.
+/* becomes */
 
+h1 {
+  color: red;
+  color: var(--color);
+}
 
-### `noValueNotifications`
+:root {
+  --color: red;
+}
+```
 
-Default: `'warning'`
-Values: `'warning'|'error'`
+### warnings
 
-If it is set to `'error'`, using of undefined variable will throw an error.
+The `warnings` option determines whether Custom Property related warnings should
+be logged by the plugin or not. By default, warnings are set to `false` and are
+not logged.
 
+If enabled, the plugin will enable all warnings:
+
+```js
+postCSSCustomProperties({
+  warnings: true
+})
+```
+
+```css
+h1 {
+  color: var(--color);
+}
+```
+
+```
+variable '--color' is undefined and used without a fallback
+```
+
+### noValueNotifications
+
+When warnings are enabled, the `noValueNotifications` option determines whether
+undefined variables will throw a warning or an error. By default, it is set to
+`warning`.
 
 ---
+
+## Notes
+
+As written in the specification, usage of `var()` is limited to property values.
+Do not expect the plugin to transform `var()` in media queries or in selectors.
+
+The transformation of Custom Properties done by this plugin _is not complete_
+and **cannot be** because dynamic *cascading* variables based on custom
+properties relies on the DOM tree. Since we do not know the DOM in the context
+of this plugin, we cannot produce safe output. This plugin currently aims to
+provide a future-proof way of using a **limited subset** of the features
+provided by native CSS custom properties.
+
+There is a separate plugin, [PostCSS CSS Variables], that attempts to guess the
+context of Custom Properties without access to the DOM tree. This does not
+[reflecting the specifications](https://github.com/MadLittleMods/postcss-css-variables/issues/4),
+so be sure you understand the risks before you decide to use it.
 
 ## Contributing
 
 Fork, work on a branch, install dependencies & run tests before submitting a PR.
 
-```console
+```bash
 $ git clone https://github.com/YOU/postcss-custom-properties.git
 $ git checkout -b patch-1
 $ npm install
 $ npm test
 ```
 
+---
+
 ## [Changelog](CHANGELOG.md)
 
 ## [License](LICENSE)
+
+[npm-url]: https://www.npmjs.com/package/postcss-custom-properties
+[npm-img]: https://img.shields.io/npm/v/postcss-custom-properties.svg
+[css-url]: https://jonathantneal.github.io/css-db/#css-variables
+[css-img]: https://jonathantneal.github.io/css-db/badge/css-variables.svg
+[cli-url]: https://travis-ci.org/postcss/postcss-custom-properties
+[cli-img]: https://img.shields.io/travis/postcss/postcss-custom-properties.svg
+[git-url]: https://gitter.im/postcss/postcss
+[git-img]: https://img.shields.io/badge/chat-gitter-blue.svg
+
+[CSS Custom Properties for Cascading Variables]: https://www.w3.org/TR/css-variables-1/
+[PostCSS CSS Variables]: https://github.com/MadLittleMods/postcss-css-variables
+[PostCSS Custom Properties]: https://github.com/postcss/postcss-custom-properties
+[PostCSS]: https://github.com/postcss/postcss
+[Gulp PostCSS]: https://github.com/postcss/gulp-postcss
+[Grunt PostCSS]: https://github.com/nDmitry/grunt-postcss

--- a/index.js
+++ b/index.js
@@ -163,15 +163,17 @@ export default postcss.plugin("postcss-custom-properties", (options = {}) => {
 
   function plugin(style, result) {
     const variables = prefixVariables(options.variables)
-    const strict = options.strict === undefined ? true : options.strict
-    const appendVariables = options.appendVariables
-    const preserve = options.preserve
+    const strict = "strict" in options ? Boolean(options.strict) : true
+    const appendVariables = "appendVariables" in options
+      ? Boolean(options.appendVariables) : false
+    const preserve = "preserve" in options ? options.preserve : null
     const map = {}
     const importantMap = {}
 
     globalOpts = {
-      warnings: options.warnings === undefined ? true : options.warnings,
-      noValueNotifications: options.noValueNotifications || "warning",
+      warnings: "warnings" in options ? Boolean(options.warnings) : true,
+      noValueNotifications: "noValueNotifications" in options
+        ? String(options.noValueNotifications) : "warning",
     }
 
     // define variables

--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ export default postcss.plugin("postcss-custom-properties", (options = {}) => {
     const importantMap = {}
 
     globalOpts = {
-      warnings: "warnings" in options ? Boolean(options.warnings) : true,
+      warnings: "warnings" in options ? Boolean(options.warnings) : false,
       noValueNotifications: "noValueNotifications" in options
         ? String(options.noValueNotifications) : "warning",
     }

--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ export default postcss.plugin("postcss-custom-properties", (options = {}) => {
     const strict = "strict" in options ? Boolean(options.strict) : true
     const appendVariables = "appendVariables" in options
       ? Boolean(options.appendVariables) : false
-    const preserve = "preserve" in options ? options.preserve : null
+    const preserve = "preserve" in options ? options.preserve : true
     const map = {}
     const importantMap = {}
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const VAR_PROP_IDENTIFIER = "--"
 const VAR_FUNC_IDENTIFIER = "var"
 const VAR_FUNC_REGEX = /(^|[^\w-])var\(/
 // matches `name[, fallback]`, captures "name" and "fallback"
-const RE_VAR = /([\w-]+)(?:\s*,\s*)?\s*(.*)?/
+const RE_VAR = /[\f\n\r\t ]*([\w-]+)(?:[\f\n\r\t ]*,[\f\n\r\t ]*([\W\w]+))?/
 
 /**
  * Module variables

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
   ],
   "dependencies": {
     "balanced-match": "^1.0.0",
-    "postcss": "^6.0.13"
+    "postcss": "^6.0.18"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-preset-env": "^1.6.0",
+    "babel-preset-env": "^1.6.1",
     "babel-register": "^6.26.0",
-    "eslint": "^4.8.0",
+    "eslint": "^4.17.0",
     "npmpub": "^3.1.0",
     "tape": "^4.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-custom-properties",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "PostCSS plugin to polyfill W3C CSS Custom Properties for cascading variables",
   "keywords": [
     "css",

--- a/test/fixtures/automatic-variable-prefix.expected.css
+++ b/test/fixtures/automatic-variable-prefix.expected.css
@@ -1,4 +1,6 @@
 div {
   color: blue;
+  color: var(--unprefixed);
   background: white;
+  background: var(--prefixed);
 }

--- a/test/fixtures/case-sensitive.expected.css
+++ b/test/fixtures/case-sensitive.expected.css
@@ -1,4 +1,11 @@
+:root {
+  --TEST-color: red;
+  --tESt-COLOR: green;
+}
+
 div {
   color: red;
+  color: var(--TEST-color);
   color: green;
+  color: var(--tESt-COLOR);
 }

--- a/test/fixtures/circular-reference.expected.css
+++ b/test/fixtures/circular-reference.expected.css
@@ -1,3 +1,10 @@
+:root {
+    --color: var(--color);
+    --color: var(--bg-color);
+    --bg-color: var(--color);
+    --bg-color: var(--color);
+}
 body {
-	color: var(--bg-color);
+	color: var(--color);
+	color: var(--color);
 }

--- a/test/fixtures/important.expected.css
+++ b/test/fixtures/important.expected.css
@@ -1,5 +1,19 @@
+:root {
+ --one: not important;
+ --one: important !important;
+
+ --two: important !important;
+ --two: not important;
+
+ --three: important !important;
+ --three: more important !important;
+}
+
 selector {
  one: important;
+ one: var(--one);
  two: important;
+ two: var(--two);
  three: more important;
+ three: var(--three);
 }

--- a/test/fixtures/js-defined.expected.css
+++ b/test/fixtures/js-defined.expected.css
@@ -1,8 +1,19 @@
+:root {
+  --test-one: local;
+  --test-two: local;
+}
+
 div {
   p: js-one;
+  p: var(--test-one);
   p: js-two;
+  p: var(--test-two);
   p: js-three;
+  p: var(--test-three);
   p: js-one;
+  p: var(--test-varception);
   p: js-one;
+  p: var(--test-jsception);
   p: 1;
+  p: var(--test-num);
 }

--- a/test/fixtures/js-override.expected.css
+++ b/test/fixtures/js-override.expected.css
@@ -1,8 +1,19 @@
+:root {
+  --test-one: local;
+  --test-two: local;
+}
+
 div {
   p: js-one;
+  p: var(--test-one);
   p: js-two;
+  p: var(--test-two);
   p: js-three;
+  p: var(--test-three);
   p: js-one;
+  p: var(--test-varception);
   p: js-one;
+  p: var(--test-jsception);
   p: 1;
+  p: var(--test-num);
 }

--- a/test/fixtures/remove-properties.expected.css
+++ b/test/fixtures/remove-properties.expected.css
@@ -1,3 +1,13 @@
+:root {
+  --test-one: test;
+  --test-two: test;
+}
+
 div {
   color: red;
+}
+
+:root {
+  --test-three: test;
+  --test-four: test;
 }

--- a/test/fixtures/self-reference-double-fallback.expected.css
+++ b/test/fixtures/self-reference-double-fallback.expected.css
@@ -1,4 +1,12 @@
+:root {
+	--color: #aaa;
+	--color: #aaa;
+	--color: #aaa;
+	--color: var(--color, #aaa);
+}
 body {
 	color: #bbb;
 	color: #aaa;
+	color: #aaa;
+	color: var(--color, #bbb);
 }

--- a/test/fixtures/self-reference-fallback.expected.css
+++ b/test/fixtures/self-reference-fallback.expected.css
@@ -1,3 +1,8 @@
+:root {
+	--color: var(--color);
+	--color: var(--color);
+}
 body {
 	color: #aaa;
+	color: var(--color, #aaa);
 }

--- a/test/fixtures/self-reference.expected.css
+++ b/test/fixtures/self-reference.expected.css
@@ -1,3 +1,8 @@
+:root {
+	--color: var(--color);
+	--color: var(--color);
+}
 body {
+	color: var(--color);
 	color: var(--color);
 }

--- a/test/fixtures/substitution-defined.expected.css
+++ b/test/fixtures/substitution-defined.expected.css
@@ -2,6 +2,15 @@
  * Test comment
  */
 
+:root {
+  --test: green;
+  --test-one: green;
+  --test-one: var(--test);
+
+  --test-two: blue;
+  --test-three: yellow;
+}
+
 :root,
 span {
   --untouched: red;
@@ -12,23 +21,30 @@ div {
 
   /* single variable */
   color: green;
+  color: var(--test-one);
 
   /* single variable with comments */
   color: /*comment before*/green/*comment after*/;
+  color: /*comment before*/var(--test-one)/*comment after*/;
 
   /* single variable with tail */
   color: green !important;
+  color: var(--test-one) !important;
 
   /* multiple variables */
   color: green, blue;
+  color: var(--test-one), var(--test-two);
 
   /* variable with function in fallback */
   border: 1px solid rgba(0, 0, 0, 0.1);
   border: green;
+  border: var(--test-one, 1px solid rgba(0, 0, 0, 0.1));
 
   /* multiple variables within a function */
   background: linear-gradient(to top, green, blue);
+  background: linear-gradient(to top, var(--test-one), var(--test-two));
 
   /* untouched custom function */
+  color: myvar(--test-one);
   color: myvar(--test-one);
 }

--- a/test/fixtures/substitution-fallback.expected.css
+++ b/test/fixtures/substitution-fallback.expected.css
@@ -1,33 +1,47 @@
+:root {
+  --nested: green;
+}
+
 div {
   /* simple fallback */
   color: green;
+  color: var(--missing, green);
 
   /* comma-separated fallback */
   color: green, blue;
+  color: var(--missing, green, blue);
 
   /* fallback is a function */
   background: linear-gradient(to top, #000, #111);
+  background: var(--missing, linear-gradient(to top, #000, #111));
 
   /* fallback contains a function */
   background: 1px solid rgba(0, 0, 0, 0.1);
+  background: var(--missing, 1px solid rgba(0, 0, 0, 0.1));
 
   /* fallback is a function containing a function */
   background: linear-gradient(to top, #000, rgba(0, 0, 0, 0.5));
+  background: var(--missing, linear-gradient(to top, #000, rgba(0, 0, 0, 0.5)));
 
   /* fallback contains a defined variable */
   background: green;
+  background: var(--missing, var(--nested));
 
   /* fallback contains a defined variable within a function */
   background: linear-gradient(to top, #000, green);
+  background: var(--missing, linear-gradient(to top, #000, var(--nested)));
 
   /* fallback contains an undefined variable with a fallack */
   background: green;
+  background: var(--missing, var(--also-missing, green));
 
   /* fallback for invalid variables http://www.w3.org/TR/css-variables/#invalid-variables */
   font-size: 1rem;
   font-size: green;
+  font-size: var(--nested, 1rem);
 
   /* fallback contains an defined variable with a fallack */
   font-size: 1rem;
   font-size: green;
+  font-size: var(--missing, var(--nested, 1rem));
 }

--- a/test/fixtures/substitution-overwrite.expected.css
+++ b/test/fixtures/substitution-overwrite.expected.css
@@ -1,4 +1,14 @@
+:root {
+  --test-override: red;
+}
+
 div {
   background: green;
+  background: var(--test-override);
   color: green;
+  color: var(--test-override);
+}
+
+:root {
+  --test-override: green;
 }

--- a/test/fixtures/substitution-strict.expected.css
+++ b/test/fixtures/substitution-strict.expected.css
@@ -1,5 +1,14 @@
+:root {
+  --a: "a";
+  --b: bFallback;
+  --b: var(--bUndef, bFallback);
+}
+
 div {
   aProp: "a";
+  aProp: var(--a, aPropFallback);
   bProp: bFallback;
+  bProp: var(--b, bPropFallback);
   bProp: cPropFallback;
+  bProp: var(--cUndef, cPropFallback);
 }

--- a/test/fixtures/substitution-trailing-space.expected.css
+++ b/test/fixtures/substitution-trailing-space.expected.css
@@ -1,3 +1,8 @@
+:root {
+  --test-trailing-space: red;
+}
+
 div {
   color: red;
+  color: var( --test-trailing-space );
 }

--- a/test/fixtures/substitution-undefined.expected.css
+++ b/test/fixtures/substitution-undefined.expected.css
@@ -1,8 +1,18 @@
+:root {
+  --defined: true
+}
+
 div {
   color: var(--test);
+  color: var(--test);
   color: fallback;
+  color: var(--test, fallback);
+  background: linear-gradient(var(--a), var(--b));
   background: linear-gradient(var(--a), var(--b));
   background: linear-gradient(var(--a), var(--b), true);
+  background: linear-gradient(var(--a), var(--b), var(--defined));
   background: linear-gradient(var(--a), true , var(--b));
+  background: linear-gradient(var(--a), var(--defined) , var(--b));
   background: linear-gradient(var(--a), true , var(--b), true);
+  background: linear-gradient(var(--a), var(--defined) , var(--b), var(--defined));
 }

--- a/test/index.js
+++ b/test/index.js
@@ -61,7 +61,9 @@ test("throw errors", function(t) {
 test(
   "substitutes nothing when a variable function references an undefined var",
   function(t) {
-    const result = compareFixtures(t, "substitution-undefined")
+    const result = compareFixtures(t, "substitution-undefined", {
+      warnings: true,
+    })
     t.equal(
       result.messages[0].text,
       "variable '--test' is undefined and used without a fallback",
@@ -78,6 +80,7 @@ test(
       function() {
         return postcss(customProperties({
           noValueNotifications: "error",
+          warnings: true,
         }))
           .process(fixture("substitution-undefined"))
           .css
@@ -90,7 +93,9 @@ test(
 )
 
 test("substitutes defined variables in `:root` only", function(t) {
-  const result = compareFixtures(t, "substitution-defined")
+  const result = compareFixtures(t, "substitution-defined", {
+    warnings: true,
+  })
   t.ok(
     result.messages[0].text.match(/^Custom property ignored/),
     "should add a warning for non root custom properties"
@@ -212,7 +217,9 @@ test("preserves computed value when `preserve` is `\"computed\"`", function(t) {
 
 test("circular variable references", function(t) {
   compareFixtures(t, "self-reference")
-  const result = compareFixtures(t, "circular-reference")
+  const result = compareFixtures(t, "circular-reference", {
+    warnings: true,
+  })
   t.equal(
     result.messages[0].text,
     "Circular variable reference: --bg-color",

--- a/test/index.js
+++ b/test/index.js
@@ -215,7 +215,7 @@ test("circular variable references", function(t) {
   const result = compareFixtures(t, "circular-reference")
   t.equal(
     result.messages[0].text,
-    "Circular variable reference: --color",
+    "Circular variable reference: --bg-color",
     "should add a warning for circular reference"
   )
   t.end()


### PR DESCRIPTION
- Fixed: `var()` captures strictly `var()` functions and not `xvar()`, etc
- Fixed: `var()` better captures whitespace within the function
- Fixed: comments within declarations using `var()` are now preserved
- Changed: `preserve` option defaults as `true` to reflect the browser climate
- Changed: `warnings` option defaults to `false` to reflect the browser climate
- Updated documentation