### PR TITLE
7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 7.0.0 - 2018-02-16
+
+- Changed: `preserve` option defaults as `true` to reflect the browser climate
+- Changed: `warnings` option defaults to `false` to reflect the browser climate
+
 # 6.3.1 - 2018-02-16
 
 - Reverted: `preserve` and `warnings` option to be added in major release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.3.1 - 2018-02-16
+
+- Reverted: `preserve` and `warnings` option to be added in major release
+
 # 6.3.0 - 2018-02-15
 
 - Fixed: `var()` captures strictly `var()` functions and not `xvar()`, etc

--- a/index.js
+++ b/index.js
@@ -166,12 +166,12 @@ export default postcss.plugin("postcss-custom-properties", (options = {}) => {
     const strict = "strict" in options ? Boolean(options.strict) : true
     const appendVariables = "appendVariables" in options
       ? Boolean(options.appendVariables) : false
-    const preserve = "preserve" in options ? options.preserve : false
+    const preserve = "preserve" in options ? options.preserve : true
     const map = {}
     const importantMap = {}
 
     globalOpts = {
-      warnings: "warnings" in options ? Boolean(options.warnings) : true,
+      warnings: "warnings" in options ? Boolean(options.warnings) : false,
       noValueNotifications: "noValueNotifications" in options
         ? String(options.noValueNotifications) : "warning",
     }

--- a/index.js
+++ b/index.js
@@ -166,12 +166,12 @@ export default postcss.plugin("postcss-custom-properties", (options = {}) => {
     const strict = "strict" in options ? Boolean(options.strict) : true
     const appendVariables = "appendVariables" in options
       ? Boolean(options.appendVariables) : false
-    const preserve = "preserve" in options ? options.preserve : true
+    const preserve = "preserve" in options ? options.preserve : false
     const map = {}
     const importantMap = {}
 
     globalOpts = {
-      warnings: "warnings" in options ? Boolean(options.warnings) : false,
+      warnings: "warnings" in options ? Boolean(options.warnings) : true,
       noValueNotifications: "noValueNotifications" in options
         ? String(options.noValueNotifications) : "warning",
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-custom-properties",
-  "version": "6.3.1",
+  "version": "7.0.0",
   "description": "PostCSS plugin to polyfill W3C CSS Custom Properties for cascading variables",
   "keywords": [
     "css",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-custom-properties",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "PostCSS plugin to polyfill W3C CSS Custom Properties for cascading variables",
   "keywords": [
     "css",


### PR DESCRIPTION
- Changed: `preserve` option defaults as `true` to reflect the browser climate
- Changed: `warnings` option defaults to `false` to reflect the browser climate

Includes the commit for 6.3.1, which has been published as a hotfix for breaking changes in 6.3.0.

Resolves #93