### PR TITLE
Fix appendVariables appending duplicate vars

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,25 +276,27 @@ export default postcss.plugin("postcss-custom-properties", (options = {}) => {
       }
     })
 
-    if (preserve && appendVariables) {
+    if (preserve && variables && appendVariables) {
       const names = Object.keys(map)
       if (names.length) {
         const container = postcss.rule({
           selector: ":root",
           raws: {semicolon: true},
         })
-        names.forEach((name) => {
-          const variable = map[name]
-          let val = variable.value
-          if (variable.resolved) {
-            val = val[val.length - 1]
-          }
-          const decl = postcss.decl({
-            prop: name,
-            value: val,
+        names
+          .filter((name) => variables.hasOwnProperty(name))
+          .forEach((name) => {
+            const variable = map[name]
+            let val = variable.value
+            if (variable.resolved) {
+              val = val[val.length - 1]
+            }
+            const decl = postcss.decl({
+              prop: name,
+              value: val,
+            })
+            container.append(decl)
           })
-          container.append(decl)
-        })
         style.append(container)
       }
     }

--- a/test/fixtures/append.duplicates.css
+++ b/test/fixtures/append.duplicates.css
@@ -1,0 +1,8 @@
+:root {
+	--test-one: css-one;
+}
+
+div {
+	p: var(--test-one);
+	a: var(--test-two);
+}

--- a/test/fixtures/append.duplicates.expected.css
+++ b/test/fixtures/append.duplicates.expected.css
@@ -1,0 +1,14 @@
+:root {
+	--test-one: css-one;
+}
+
+div {
+	p: css-one;
+	a: js-one;
+}
+
+:root {
+	--test-two: js-one;
+	--test-three: js-two;
+	--test-four: css-one js-one js-two;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,7 @@ function compareFixtures(t, name, options) {
   const actual = postcssResult.css.trim()
 
   // handy thing: checkout actual in the *.actual.css file
-  fs.writeFile(fixturePath(name + ".actual"), actual)
+  fs.writeFile(fixturePath(name + ".actual"), actual, () => {})
 
   const expected = fixture(name + ".expected")
   t.equal(

--- a/test/index.js
+++ b/test/index.js
@@ -247,6 +247,20 @@ test("append variables", function(t) {
   t.end()
 })
 
+test("append variables without duplicates", function(t) {
+  compareFixtures(t, "append.duplicates", {
+    variables: {
+      "--test-two": "js-one",
+      "test-three": "js-two",
+      "test-four": "var(--test-one, one) var(--test-two, two) " +
+          "var(--test-three, three)",
+    },
+    preserve: "computed",
+    appendVariables: true,
+  })
+  t.end()
+})
+
 test("strict option", function(t) {
   compareFixtures(t, "substitution-strict", {
     strict: false,


### PR DESCRIPTION
When the appendVariables and preserve options are set, it would append both JavaScript-provided variables as well as variables declared in CSS, leading to duplicates. This will filter out non-JS variables so we don't end up with duplicate declarations.

Fixes #114 