### PR TITLE
allow vars to be defined in either :root or html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist
 node_modules
 test/fixtures/*.actual.css
+.vscode/settings.json
+vscode.code-workspace

--- a/README.md
+++ b/README.md
@@ -291,6 +291,41 @@ h1 {
 }
 ```
 
+### root
+
+The `root` option determined which root node to insert `variables` into. The 
+value can be either `:root` or `html`. By default, the option is set to `:root`. 
+
+If `appendVariables` is enabled and `preserve` is set to `true` or `"computed"`, 
+variables will be a appended to the css inside of the specified root. 
+
+```js
+postCSSCustomProperties({
+  root: 'html',
+  appendVariables: true,
+  variables: {
+    color: 'red'
+  }
+})
+```
+
+```css
+h1 {
+  color: var(--color);
+}
+
+/* becomes */
+
+h1 {
+  color: red;
+  color: var(--color);
+}
+
+html {
+  --color: red;
+}
+```
+
 ### warnings
 
 The `warnings` option determines whether Custom Property related warnings should

--- a/index.js
+++ b/index.js
@@ -167,6 +167,12 @@ export default postcss.plugin("postcss-custom-properties", (options = {}) => {
     const appendVariables = "appendVariables" in options
       ? Boolean(options.appendVariables) : false
     const preserve = "preserve" in options ? options.preserve : true
+    const root = "root" in options 
+      && (options.root == ":root" 
+      || options.root == "html")
+      ? options.root
+      : ":root"
+
     const map = {}
     const importantMap = {}
 
@@ -180,10 +186,10 @@ export default postcss.plugin("postcss-custom-properties", (options = {}) => {
     style.walkRules((rule) => {
       const toRemove = []
 
-      // only variables declared for `:root` are supported for now
+      // only variables declared for `:root` or `html` are supported for now
       if (
         rule.selectors.length !== 1 ||
-        rule.selectors[0] !== ":root" ||
+        !(rule.selectors[0] == ":root" || rule.selectors[0] == "html") ||
         rule.parent.type !== "root"
       ) {
         rule.each((decl) => {
@@ -194,7 +200,8 @@ export default postcss.plugin("postcss-custom-properties", (options = {}) => {
             prop.indexOf(VAR_PROP_IDENTIFIER) === 0
           ) {
             result.warn(
-              "Custom property ignored: not scoped to the top-level :root " +
+              "Custom property ignored: not scoped to the top-level " +
+              ":root or html " +
               `element (${rule.selectors} { ... ${prop}: ... })` +
               (rule.parent.type !== "root" ? ", in " + rule.parent.type : ""),
               {node: decl}
@@ -280,7 +287,7 @@ export default postcss.plugin("postcss-custom-properties", (options = {}) => {
       const names = Object.keys(map)
       if (names.length) {
         const container = postcss.rule({
-          selector: ":root",
+          selector: root,
           raws: {semicolon: true},
         })
         names

--- a/test/fixtures/html-root.css
+++ b/test/fixtures/html-root.css
@@ -1,0 +1,11 @@
+html {
+    --test-one: red; 
+}
+:root {
+    --test-two: blue;
+}
+
+div {
+    color: var(--test-one);
+    background-color: var(--test-two);
+}

--- a/test/fixtures/html-root.expected.css
+++ b/test/fixtures/html-root.expected.css
@@ -1,0 +1,13 @@
+html {
+    --test-one: red; 
+}
+:root {
+    --test-two: blue;
+}
+
+div {
+    color: red;
+    color: var(--test-one);
+    background-color: blue;
+    background-color: var(--test-two);
+}

--- a/test/fixtures/js-root.css
+++ b/test/fixtures/js-root.css
@@ -1,0 +1,13 @@
+:root {
+    --test-one: local;
+  }
+  
+  div {
+    p: var(--test-one);
+    p: var(--test-two);
+    p: var(--test-three);
+    p: var(--test-varception);
+    p: var(--test-jsception);
+    p: var(--test-num);
+  }
+  

--- a/test/fixtures/js-root.expected.css
+++ b/test/fixtures/js-root.expected.css
@@ -1,0 +1,26 @@
+:root {
+    --test-one: local;
+  }
+  
+  div {
+    p: local;
+    p: var(--test-one);
+    p: js-two;
+    p: var(--test-two);
+    p: js-three;
+    p: var(--test-three);
+    p: js-two;
+    p: var(--test-varception);
+    p: js-two;
+    p: var(--test-jsception);
+    p: 1;
+    p: var(--test-num);
+  }
+  
+  html {
+    --test-two: js-two;
+    --test-three: js-three;
+    --test-varception: js-two;
+    --test-jsception: js-two;
+    --test-num: 1;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -273,3 +273,26 @@ test("ignores trailing space after variable", function(t) {
   compareFixtures(t, "substitution-trailing-space")
   t.end()
 })
+
+test("allow variablie definitions in html root element", function(t) {
+  compareFixtures(t, "html-root")
+  t.end()
+})
+
+test(
+  "allow root option to determine in which root node js variables are set",
+  function(t) {
+    compareFixtures(t, "js-root", {
+      root: "html",
+      variables: {
+        "--test-two": "js-two",
+        "--test-three": "js-three",
+        "--test-varception": "var(--test-two)",
+        "--test-jsception": "var(--test-varception)",
+        "--test-num": 1,
+      },
+      appendVariables: true,
+    })
+    t.end()
+  }
+)


### PR DESCRIPTION
This a proposed solution to issue #100. It allows variables to be defined in either `:root` or `html`. It also adds a postcss option called `root` that allows control over which node variables will be set in. If the `variables`, `appendVariables` and `root` options are set, the variables will be appended to the css in the specified root (e.g. either `:root` or `html`). 
Two unit tests have been added for these new features as well. 