### PR TITLE
Fix calc multiple custom props with fallbacks

### DIFF
--- a/lib/transform-value-ast.js
+++ b/lib/transform-value-ast.js
@@ -15,7 +15,9 @@ export default function transformValueAST(root, customProperties) {
 					// conditionally replace a custom property with a fallback
 					const index = root.nodes.indexOf(child);
 
-					root.nodes.splice(index, 1, ...asClonedArrayWithBeforeSpacing(fallbacks, child.raws.before));
+					if (index !== -1) {
+						root.nodes.splice(index, 1, ...asClonedArrayWithBeforeSpacing(fallbacks, child.raws.before));
+					}
 
 					transformValueAST(root, customProperties);
 				}

--- a/test/basic.css
+++ b/test/basic.css
@@ -38,3 +38,7 @@ html {
 .test--nested-fallback {
 	z-index: var(--xxx, var(--yyy, 1));
 }
+
+.text--calc {
+	width: calc((100% - var(--xxx, 1px)) + var(--yyy, 10px));
+}

--- a/test/basic.expect.css
+++ b/test/basic.expect.css
@@ -44,3 +44,8 @@ html {
 	z-index: 1;
 	z-index: var(--xxx, var(--yyy, 1));
 }
+
+.text--calc {
+	width: calc((100% - 1px) + 10px);
+	width: calc((100% - var(--xxx, 1px)) + var(--yyy, 10px));
+}

--- a/test/basic.import-is-empty.expect.css
+++ b/test/basic.import-is-empty.expect.css
@@ -44,3 +44,8 @@ html {
 	z-index: 1;
 	z-index: var(--xxx, var(--yyy, 1));
 }
+
+.text--calc {
+	width: calc((100% - 1px) + 10px);
+	width: calc((100% - var(--xxx, 1px)) + var(--yyy, 10px));
+}

--- a/test/basic.import.expect.css
+++ b/test/basic.import.expect.css
@@ -45,3 +45,8 @@ html {
 	z-index: 1;
 	z-index: var(--xxx, var(--yyy, 1));
 }
+
+.text--calc {
+	width: calc((100% - 1px) + 10px);
+	width: calc((100% - var(--xxx, 1px)) + var(--yyy, 10px));
+}

--- a/test/basic.preserve.expect.css
+++ b/test/basic.preserve.expect.css
@@ -30,3 +30,7 @@
 .test--nested-fallback {
 	z-index: 1;
 }
+
+.text--calc {
+	width: calc((100% - 1px) + 10px);
+}


### PR DESCRIPTION
This fixes an issue where a `calc` with multiple `var` in it would replace the trailing parentheses with the last fallback it encountered.

An example
```css
/** source */
.text--calc {
  width: calc((100% - var(--xxx, 1px)) + var(--yyy, 10px));
}

/** before fix */
.text--calc {
  width: calc((100% - 1px) + 10px 10px;
  width: calc((100% - var(--xxx, 1px)) + var(--yyy, 10px));
}

/** after fix */
.text--calc {
  width: calc((100% - 1px) + 10px);
  width: calc((100% - var(--xxx, 1px)) + var(--yyy, 10px));
}
```