### PR TITLE
Make non-async if there's no need for awaits

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,14 @@ export default postcss.plugin('postcss-custom-properties', opts => {
 	// promise any custom selectors are imported
 	const customPropertiesPromise = getCustomPropertiesFromImports(importFrom);
 
+	// make sure we work in synchronous mode if no asynchronous operations are requested
+	if(importFrom.length === 0 && exportTo.length === 0) {
+		return root => {
+			const customProperties = getCustomPropertiesFromRoot(root, { preserve });
+			transformProperties(root, customProperties, { preserve });
+		}
+	}
+
 	return async root => {
 		const customProperties = Object.assign(
 			await customPropertiesPromise,


### PR DESCRIPTION
This makes postcss-custom-properties act as a synchronous plugin (i.e. so users don't need to `await` the result of `postcss(..).process()`), if and only if nothing is imported nor exported.

Some background: we're trying to use postcss-custom-properties in a server setup where user-written CSS is compiled down. For many practical reasons, making the entire pipeline asynchronous is prohibitively hard, and given that we don't use any importing/exporting, we found ourselves wishing postcss-custom-properties was just a synchronous thing altogether. Well, now it is :-)

Given that some of the existing tests don't import or export things, the new code is automatically covered. So I've not added any tests.

I don't have an extremely detailed understanding of the internals of postcss, but if I understand it right, plugins can either return or promise or not, and postcss papers over the difference pretty transparently. Notably, I believe that you can `await` a postcss pipeline even if all plugins happened to have run synchronously - that would be pretty important for this change to be backward compatible. My limited manual testing shows that this is indeed the case but I might have missed some edge case.