### PR TITLE
Prevent mutation and unexpected situations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ export default postcss.plugin('postcss-custom-properties', opts => {
 
 	return async root => {
 		const customProperties = Object.assign(
+			{},
 			await customPropertiesPromise,
 			getCustomPropertiesFromRoot(root, { preserve })
 		);


### PR DESCRIPTION
Even if no `importFrom` was specified, the previous version (before this change) would re-use the same object. This causes 'sharing' of properties between different files. It also means that if two files declare the same variable with a different value, things can become quite tricky. This is made even more strange by having the `await` between property retrieval and application. We have situations where before the `await` a prop has one value and after the `await` another value.