### PR TITLE
8.0.11

### DIFF
--- a/.rollup.js
+++ b/.rollup.js
@@ -3,8 +3,8 @@ import babel from 'rollup-plugin-babel';
 export default {
 	input: 'src/index.js',
 	output: [
-		{ file: 'index.js', format: 'cjs', sourcemap: true },
-		{ file: 'index.mjs', format: 'esm', sourcemap: true }
+		{ file: 'index.cjs.js', format: 'cjs', sourcemap: true },
+		{ file: 'index.esm.mjs', format: 'esm', sourcemap: true }
 	],
 	plugins: [
 		babel({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to PostCSS Custom Properties
 
+### 8.0.11 (June 20, 2019)
+
+- Added: Synchronous transforms when async is unnecessary (thank @eteeselink)
+- Fixed: Unexpected mutations to imported Custom Properties (thank @EECOLOR)
+- Fixed: Transforms throwing over unknown Custom Properties
+
 ### 8.0.10 (April 1, 2019)
 
 - Added: Support for ignoring lines and or blocks using

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-custom-properties",
-  "version": "8.0.10",
+  "version": "8.0.11",
   "description": "Use Custom Properties Queries in CSS",
   "author": "Jonathan Neal <jonathantneal@hotmail.com>",
   "contributors": [
@@ -38,7 +38,7 @@
     "@babel/preset-env": "^7.4.5",
     "babel-eslint": "^10.0.2",
     "eslint": "^5.16.0",
-    "postcss-tape": "^5.0.0",
+    "postcss-tape": "^4.0.0",
     "pre-commit": "^1.2.2",
     "rollup": "^1.15.6",
     "rollup-plugin-babel": "^4.3.2"

--- a/package.json
+++ b/package.json
@@ -10,43 +10,53 @@
   "repository": "postcss/postcss-custom-properties",
   "homepage": "https://github.com/postcss/postcss-custom-properties#readme",
   "bugs": "https://github.com/postcss/postcss-custom-properties/issues",
-  "main": "index.js",
-  "module": "index.mjs",
+  "main": "index.cjs.js",
+  "module": "index.esm.mjs",
   "files": [
-    "index.js",
-    "index.js.map",
-    "index.mjs",
-    "index.mjs.map"
+    "index.cjs.js",
+    "index.cjs.js.map",
+    "index.esm.mjs",
+    "index.esm.mjs.map"
   ],
   "scripts": {
     "prepublishOnly": "npm test",
     "pretest:tape": "rollup -c .rollup.js --silent",
     "test": "npm run test:js && npm run test:tape",
-    "test:js": "eslint src/**/*.js --cache --ignore-path .gitignore --quiet",
+    "test:js": "eslint src/{*,**/*}.js --cache --ignore-path .gitignore --quiet",
     "test:tape": "postcss-tape"
   },
   "engines": {
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "postcss": "^7.0.14",
-    "postcss-values-parser": "^3.0.3"
+    "postcss": "^7.0.17",
+    "postcss-values-parser": "^2.0.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.4.0",
+    "@babel/core": "^7.4.5",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
-    "@babel/preset-env": "^7.4.2",
-    "babel-eslint": "^10.0.1",
+    "@babel/preset-env": "^7.4.5",
+    "babel-eslint": "^10.0.2",
     "eslint": "^5.16.0",
-    "eslint-config-dev": "^2.0.0",
-    "postcss-tape": "^4.0.0",
+    "postcss-tape": "^5.0.0",
     "pre-commit": "^1.2.2",
-    "rollup": "^1.7.4",
+    "rollup": "^1.15.6",
     "rollup-plugin-babel": "^4.3.2"
   },
   "eslintConfig": {
-    "extends": "dev",
-    "parser": "babel-eslint"
+    "env": {
+      "browser": true,
+      "es6": true,
+      "node": true
+    },
+    "extends": "eslint:recommended",
+    "parser": "babel-eslint",
+    "parserOptions": {
+      "ecmaVersion": 2018,
+      "impliedStrict": true,
+      "sourceType": "module"
+    },
+    "root": true
   },
   "keywords": [
     "postcss",

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,14 @@ export default postcss.plugin('postcss-custom-properties', opts => {
 	// promise any custom selectors are imported
 	const customPropertiesPromise = getCustomPropertiesFromImports(importFrom);
 
+	// make sure we work in synchronous mode if no asynchronous operations are requested
+	if(importFrom.length === 0 && exportTo.length === 0) {
+		return root => {
+			const customProperties = getCustomPropertiesFromRoot(root, { preserve });
+			transformProperties(root, customProperties, { preserve });
+		}
+	}
+
 	return async root => {
 		const customProperties = Object.assign(
 			{},

--- a/src/index.js
+++ b/src/index.js
@@ -17,15 +17,15 @@ export default postcss.plugin('postcss-custom-properties', opts => {
 	// promise any custom selectors are imported
 	const customPropertiesPromise = getCustomPropertiesFromImports(importFrom);
 
-	// make sure we work in synchronous mode if no asynchronous operations are requested
-	if(importFrom.length === 0 && exportTo.length === 0) {
-		return root => {
-			const customProperties = getCustomPropertiesFromRoot(root, { preserve });
-			transformProperties(root, customProperties, { preserve });
-		}
-	}
+	// synchronous transform
+	const syncTransform = root => {
+		const customProperties = getCustomPropertiesFromRoot(root, { preserve });
 
-	return async root => {
+		transformProperties(root, customProperties, { preserve });
+	};
+
+	// asynchronous transform
+	const asyncTransform = async root => {
 		const customProperties = Object.assign(
 			{},
 			await customPropertiesPromise,
@@ -36,4 +36,9 @@ export default postcss.plugin('postcss-custom-properties', opts => {
 
 		transformProperties(root, customProperties, { preserve });
 	};
+
+	// whether to return synchronous function if no asynchronous operations are requested
+	const canReturnSyncFunction = importFrom.length === 0 && exportTo.length === 0;
+
+	return canReturnSyncFunction ? syncTransform : asyncTransform;
 });

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ export default postcss.plugin('postcss-custom-properties', opts => {
 
 	return async root => {
 		const customProperties = Object.assign(
+			{},
 			await customPropertiesPromise,
 			getCustomPropertiesFromRoot(root, { preserve })
 		);

--- a/src/lib/get-custom-properties-from-imports.js
+++ b/src/lib/get-custom-properties-from-imports.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import postcss from 'postcss';
-import { parse } from 'postcss-values-parser';
+import { parse } from './postcss-values-parser';
 import getCustomPropertiesFromRoot from './get-custom-properties-from-root';
 
 /* Get Custom Properties from CSS File

--- a/src/lib/get-custom-properties-from-root.js
+++ b/src/lib/get-custom-properties-from-root.js
@@ -1,4 +1,4 @@
-import { parse } from 'postcss-values-parser';
+import { parse } from './postcss-values-parser';
 import { isBlockIgnored } from './is-ignored';
 
 // return custom selectors from the css root, conditionally removing them

--- a/src/lib/postcss-values-parser.js
+++ b/src/lib/postcss-values-parser.js
@@ -1,0 +1,5 @@
+import valueParser from 'postcss-values-parser';
+
+export function parse (string) {
+	return valueParser(string).parse();
+}

--- a/src/lib/transform-properties.js
+++ b/src/lib/transform-properties.js
@@ -1,4 +1,4 @@
-import { parse } from 'postcss-values-parser';
+import { parse } from './postcss-values-parser';
 import transformValueAST from './transform-value-ast';
 import { isRuleIgnored } from './is-ignored';
 

--- a/src/lib/transform-value-ast.js
+++ b/src/lib/transform-value-ast.js
@@ -3,7 +3,7 @@ export default function transformValueAST(root, customProperties) {
 		root.nodes.slice().forEach(child => {
 			if (isVarFunction(child)) {
 				// eslint-disable-next-line no-unused-vars
-				const [propertyNode, comma, ...fallbacks] = child.nodes;
+				const [propertyNode, comma, ...fallbacks] = child.nodes.slice(1, -1);
 				const { value: name } = propertyNode;
 
 				if (name in Object(customProperties)) {
@@ -45,7 +45,7 @@ function retransformValueAST(root, customProperties, withoutProperty) {
 const varRegExp = /^var$/i;
 
 // whether the node is a var() function
-const isVarFunction = node => node.type === 'func' && varRegExp.test(node.name) && Object(node.nodes).length > 0;
+const isVarFunction = node => node.type === 'func' && varRegExp.test(node.value) && Object(node.nodes).length > 0;
 
 // return an array with its nodes cloned, preserving the raw
 const asClonedArrayWithBeforeSpacing = (array, beforeSpacing) => {

--- a/src/lib/transform-value-ast.js
+++ b/src/lib/transform-value-ast.js
@@ -6,7 +6,7 @@ export default function transformValueAST(root, customProperties) {
 				const [propertyNode, comma, ...fallbacks] = child.nodes;
 				const { value: name } = propertyNode;
 
-				if (name in customProperties) {
+				if (name in Object(customProperties)) {
 					// conditionally replace a known custom property
 					const nodes = asClonedArrayWithBeforeSpacing(customProperties[name], child.raws.before);
 


### PR DESCRIPTION
This is a patch release with non-breaking changes that address a few issues users are facing.

I was initially unreceptive to pushing any patch releases cutting a major release with PostCSS Values Parser 3. However, I changed my mind after considering the generosity of @EECOLOR and @eteeselink, who clearly identified some issues, provided solutions as pull requests, and persisted in their efforts to convince me to publish a patch release.

To @EECOLOR and @eteeselink, thank you. You didn’t have it easy, and you still solved real problems, and along the way you helped up to 1,000,000+ weekly installers of this tool.

- Added: Synchronous transforms when async is unnecessary (thank @eteeselink)
- Fixed: Unexpected mutations to imported Custom Properties (thank @EECOLOR)
- Fixed: Transforms throwing over unknown Custom Properties