### PR TITLE
Preserve spaces in multi-part values.

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -16,6 +16,7 @@ module.exports = {
 					'--color': 'rgb(255, 0, 0)',
 					'--color-2': 'yellow',
 					'--ref-color': 'var(--color)',
+					'--margin': '0 10px 20px 30px',
 					'--z-index': 10
 				}
 			}
@@ -30,6 +31,7 @@ module.exports = {
 						'--color': 'rgb(255, 0, 0)',
 						'--color-2': 'yellow',
 						'--ref-color': 'var(--color)',
+						'--margin': '0 10px 20px 30px',
 						'--z-index': 10
 					}
 				};

--- a/src/lib/write-custom-properties-to-exports.js
+++ b/src/lib/write-custom-properties-to-exports.js
@@ -110,7 +110,10 @@ export default function writeCustomPropertiesToExports(customProperties, destina
 
 const defaultCustomPropertiesToJSON = customProperties => {
 	return Object.keys(customProperties).reduce((customPropertiesJSON, key) => {
-		customPropertiesJSON[key] = String(customProperties[key]);
+		const valueNodes = customProperties[key];
+		customPropertiesJSON[key] = valueNodes.map((propertyObject) => {
+			return propertyObject.toString();
+		}).join(' ');
 
 		return customPropertiesJSON;
 	}, {});

--- a/test/basic.css
+++ b/test/basic.css
@@ -7,6 +7,7 @@ html {
 	--ref-color: var(--color);
 	--circular: var(--circular-2);
 	--circular-2: var(--circular);
+	--margin: 0 10px 20px 30px;
 	color: var(--color);
 }
 

--- a/test/basic.expect.css
+++ b/test/basic.expect.css
@@ -7,6 +7,7 @@ html {
 	--ref-color: var(--color);
 	--circular: var(--circular-2);
 	--circular-2: var(--circular);
+	--margin: 0 10px 20px 30px;
 	color: rgb(255, 0, 0);
 	color: var(--color);
 }

--- a/test/basic.import-is-empty.expect.css
+++ b/test/basic.import-is-empty.expect.css
@@ -7,6 +7,7 @@ html {
 	--ref-color: var(--color);
 	--circular: var(--circular-2);
 	--circular-2: var(--circular);
+	--margin: 0 10px 20px 30px;
 	color: rgb(255, 0, 0);
 	color: var(--color);
 }

--- a/test/basic.import.expect.css
+++ b/test/basic.import.expect.css
@@ -7,6 +7,7 @@ html {
 	--ref-color: var(--color);
 	--circular: var(--circular-2);
 	--circular-2: var(--circular);
+	--margin: 0 10px 20px 30px;
 	color: rgb(255, 0, 0);
 	color: var(--color);
 }

--- a/test/export-properties.css
+++ b/test/export-properties.css
@@ -3,4 +3,5 @@
 	--color: rgb(255, 0, 0);
 	--circular: var(--circular-2);
 	--circular-2: var(--circular);
+	--margin: 0 10px 20px 30px;
 }

--- a/test/export-properties.js
+++ b/test/export-properties.js
@@ -3,6 +3,7 @@ module.exports = {
 		'--ref-color': 'var(--color)',
 		'--color': 'rgb(255, 0, 0)',
 		'--circular': 'var(--circular-2)',
-		'--circular-2': 'var(--circular)'
+		'--circular-2': 'var(--circular)',
+		'--margin': '0 10px 20px 30px'
 	}
 };

--- a/test/export-properties.json
+++ b/test/export-properties.json
@@ -3,6 +3,7 @@
     "--ref-color": "var(--color)",
     "--color": "rgb(255, 0, 0)",
     "--circular": "var(--circular-2)",
-    "--circular-2": "var(--circular)"
+    "--circular-2": "var(--circular)",
+    "--margin": "0 10px 20px 30px"
   }
 }

--- a/test/export-properties.mjs
+++ b/test/export-properties.mjs
@@ -2,5 +2,6 @@ export const customProperties = {
 	'--ref-color': 'var(--color)',
 	'--color': 'rgb(255, 0, 0)',
 	'--circular': 'var(--circular-2)',
-	'--circular-2': 'var(--circular)'
+	'--circular-2': 'var(--circular)',
+	'--margin': '0 10px 20px 30px'
 };


### PR DESCRIPTION
This commit fixes the bug with space separated values. Previously, `0 10px 20px 30px` would be exported with commas: `0,10px,20px,30px`. This commit preverses spaces, to export `0 10px 20px 30px` as expected.

---

Hi! We use `postcss-custom-properties` a bunch here at @UrbanCompass ! Thank you for all your work on PostCSS!

I recently came across a bug using `exportTo`. Multi-part values like `0 10px 20px 30px` would be exported with commas instead of spaces: `0,10px,20px,30px`. Exported values would look even more wild if there were commas already. For example, 

``` c
// original
border-color, background, box-shadow, color
// exported
border-color,,,background,,,box-shadow,,,color
```

This PR resolves that. Tests updated as well 😸