### PR TITLE
support for ".pcss" file resolution in importFrom option

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -100,6 +100,17 @@ module.exports = {
 		expect: 'basic.import.expect.css',
 		result: 'basic.import.result.css'
 	},
+	'basic:import-css-pcss': {
+		message: 'supports { importFrom: "test/import-properties.{p}?css" } usage',
+		options: {
+			importFrom: [
+				'test/import-properties.pcss',
+				'test/import-properties-2.css'
+			]
+		},
+		expect: 'basic.import.expect.css',
+		result: 'basic.import.result.css'
+	},
 	'basic:import-css-from': {
 		message: 'supports { importFrom: { from: "test/import-properties.css" } } usage',
 		options: {

--- a/src/lib/get-custom-properties-from-imports.js
+++ b/src/lib/get-custom-properties-from-imports.js
@@ -78,7 +78,7 @@ export default function getCustomPropertiesFromImports(sources) {
 	}).reduce(async (customProperties, source) => {
 		const { type, from } = await source;
 
-		if (type === 'css') {
+		if (type === 'css' || type === 'pcss') {
 			return Object.assign(await customProperties, await getCustomPropertiesFromCSSFile(from));
 		}
 

--- a/test/import-properties.pcss
+++ b/test/import-properties.pcss
@@ -1,0 +1,4 @@
+:root {
+	--ref-color: var(--color);
+	--z-index: 10;
+}


### PR DESCRIPTION
Fix for #209 

Solution like in https://github.com/postcss/postcss-custom-media [(get-custom-media-from-imports.js#L81)](https://github.com/postcss/postcss-custom-media/blob/master/lib/get-custom-media-from-imports.js#L81)