### PR TITLE
Export to SCSS file

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -165,6 +165,22 @@ module.exports = {
 		expect: 'basic.expect.css',
 		result: 'basic.result.css'
 	},
+	'basic:export-scss': {
+		message: 'supports { exportTo: "test/export-properties.scss" } usage',
+		options: {
+			exportTo: 'test/export-properties.scss'
+		},
+		expect: 'basic.expect.css',
+		result: 'basic.result.css',
+		before() {
+			global.__exportPropertiesString = require('fs').readFileSync('test/export-properties.scss', 'utf8');
+		},
+		after() {
+			if (global.__exportPropertiesString !== require('fs').readFileSync('test/export-properties.scss', 'utf8')) {
+				throw new Error('The original file did not match the freshly exported copy');
+			}
+		}
+	},
 	'basic:export-json': {
 		message: 'supports { exportTo: "test/export-properties.json" } usage',
 		options: {

--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ postcssCustomProperties({
 ```
 
 See example exports written to [CSS](test/export-properties.css),
-[JS](test/export-properties.js), [MJS](test/export-properties.mjs), and
-[JSON](test/export-properties.json).
+[JS](test/export-properties.js), [MJS](test/export-properties.mjs),
+[JSON](test/export-properties.json) and [SCSS](test/export-properties.scss).
 
 [cli-img]: https://img.shields.io/travis/postcss/postcss-custom-properties/master.svg
 [cli-url]: https://travis-ci.org/postcss/postcss-custom-properties

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ postcssCustomProperties({
     'and/then/this.js',   // module.exports = { customProperties: { '--color': 'red' } }
     'and/then/this.mjs',  // export const customProperties = { '--color': 'red' } }
     'and/then/that.json', // { "custom-properties": { "--color": "red" } }
+    'and/then/that.scss', // $color: red;
     cachedObject,
     customProperties => {
       customProperties    // { '--color': 'red' }

--- a/src/lib/write-custom-properties-to-exports.js
+++ b/src/lib/write-custom-properties-to-exports.js
@@ -15,6 +15,21 @@ async function writeCustomPropertiesToCssFile(to, customProperties) {
 	await writeFile(to, css);
 }
 
+/* Write Custom Properties to SCSS File
+/* ========================================================================== */
+
+async function writeCustomPropertiesToScssFile(to, customProperties) {
+	const scssContent = Object.keys(customProperties).reduce((scssLines, name) => {
+		const scssName = name.replace('--', '$');
+		scssLines.push(`${scssName}: ${customProperties[name]};`);
+
+		return scssLines;
+	}, []).join('\n');
+	const scss = `${scssContent}\n`;
+
+	await writeFile(to, scss);
+}
+
 /* Write Custom Properties to JSON file
 /* ========================================================================== */
 
@@ -87,6 +102,10 @@ export default function writeCustomPropertiesToExports(customProperties, destina
 
 				if (type === 'css') {
 					await writeCustomPropertiesToCssFile(to, customPropertiesJSON);
+				}
+
+				if (type === 'scss') {
+					await writeCustomPropertiesToScssFile(to, customPropertiesJSON);
 				}
 
 				if (type === 'js') {

--- a/test/export-properties.scss
+++ b/test/export-properties.scss
@@ -1,0 +1,10 @@
+$ref-color: var(--color);
+$color: rgb(255, 0, 0);
+$color-h: 0;
+$color-s: 100%;
+$color-l: 50%;
+$color-hsl: hsl(var(--color-h), var(--color-s), var(--color-l));
+$circular: var(--circular-2);
+$circular-2: var(--circular);
+$margin: 0 10px 20px 30px;
+$theme-color: #053;


### PR DESCRIPTION
In my project, I use CSS custom properties but I also need them as SCSS variables for use with libraries that are written in SCSS that need to be customized.

This is a rather simple implementation but it does the trick.

Another thing I'd like to add would be the ability to also resolve `var()` statements in values, so that
`--color: var(--blue);` is transformed to `--color: blue`. That would allow us to export files that are free from custom properties, so we can have a "normal" SCSS var file, for example.
However, this seems like a not so simple task...