### PR TITLE
feat: upgrade postcss-values-parser to version without high risk vulnererability

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "postcss": "^7.0.17",
-    "postcss-values-parser": "^3.0.5"
+    "postcss-values-parser": "^4.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.4",


### PR DESCRIPTION
See
- https://www.npmjs.com/advisories/1550
- https://github.com/shellscape/postcss-values-parser/issues/120