### PR TITLE
add support for disable preserve comment

### DIFF
--- a/src/lib/is-ignored.js
+++ b/src/lib/is-ignored.js
@@ -14,7 +14,17 @@ function isRuleIgnored(rule) {
 		/(!\s*)?postcss-custom-properties:\s*ignore\s+next\b/i.test(previous.text));
 }
 
+function isRulePreserved(rule) {
+	var previous = rule.prev();
+
+	return !Boolean(!isBlockIgnored(rule) &&
+		previous &&
+		previous.type === 'comment' &&
+		/(!\s*)?postcss-custom-properties:\s*disable\s+preserve\b/i.test(previous.text));
+}
+
 export {
 	isBlockIgnored,
-	isRuleIgnored
+	isRuleIgnored,
+	isRulePreserved
 }

--- a/src/lib/transform-properties.js
+++ b/src/lib/transform-properties.js
@@ -1,6 +1,6 @@
 import { parse } from 'postcss-values-parser';
 import transformValueAST from './transform-value-ast';
-import { isRuleIgnored } from './is-ignored';
+import { isRuleIgnored, isRulePreserved } from './is-ignored';
 
 // transform custom pseudo selectors with custom selectors
 export default (root, customProperties, opts) => {
@@ -13,7 +13,7 @@ export default (root, customProperties, opts) => {
 
 			// conditionally transform values that have changed
 			if (value !== originalValue) {
-				if (opts.preserve) {
+				if (opts.preserve && isRulePreserved(decl)) {
 					const beforeDecl = decl.cloneBefore({ value });
 
 					if (hasTrailingComment(beforeDecl)) {


### PR DESCRIPTION
Adds support for disabling preserve on the next line via comment: ```/* postcss-custom-properties: disable preserve */```

Resolves #163 