### PR TITLE
Upgrade postcss-values-parser to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "postcss-values-parser": "^4.0.0"
+    "postcss-values-parser": "^5.0.0"
   },
   "peerDependencies": {
     "postcss": "^8.1.0"


### PR DESCRIPTION
Hey,

postcss-values-parser@^4.0.0 installs postcss^7 as a dependency. And this has been fixed in v5 release.

<img width="610" alt="Screenshot 2021-06-02 at 18 31 46" src="https://user-images.githubusercontent.com/3923527/120509688-68470c80-c3d1-11eb-8847-221d6535db38.png">
