### PR TITLE
Replace babel-eslint with @babel/eslint-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",
+    "@babel/eslint-parser": "^7.14.4",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/preset-env": "^7.11.5",
     "@rollup/plugin-babel": "^5.2.1",
-    "babel-eslint": "^10.1.0",
     "eslint": "^7.9.0",
     "postcss": "^8.1.0",
     "postcss-tape": "^6.0.0",
@@ -53,10 +53,11 @@
       "node": true
     },
     "extends": "eslint:recommended",
-    "parser": "babel-eslint",
+    "parser": "@babel/eslint-parser",
     "parserOptions": {
       "ecmaVersion": 2018,
       "impliedStrict": true,
+      "requireConfigFile": false,
       "sourceType": "module"
     },
     "root": true


### PR DESCRIPTION
Hey,

babel-eslint has been deprecated. And it's recommended to use @babel/eslint-parser instead.

This is one of `npm i` output lines:

```
npm WARN deprecated babel-eslint@10.1.0: babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.
```
