### PR TITLE
Fix type definitions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,7 +20,7 @@ export interface PluginOptions {
 export interface Plugin {
 	(options?: PluginOptions): {
 		postcssPlugin: 'postcss-custom-properties',
-		prepare({ root: any }): (
+		prepare({ root }: { root: any }): (
 			| {
 				Declaration: (decl: any) => void;
 				Once?: undefined;


### PR DESCRIPTION
Hi! I found that `postcss-custom-properties` v12 was showing an error in my Typescript project recently (https://github.com/Automattic/wp-calypso/pull/56600)

```
node_modules/postcss-custom-properties/index.d.ts:23:19 - error TS7031: Binding element 'any' implicitly has an 'any' type.
```

This is because `prepare({ root: any })` means to destructure `root` and then assign it to the variable `any`. (An easy mistake to make; I remember doing the same thing a while ago!) It should be `prepare( { root }: Type )`, which translates to `prepare( { root }: { root: any } )`. We could also split the latter part out into its own type definition, but this gets the job done.

To test this, I copied original file to the TS playground, and it has an error ([link to playground](https://www.typescriptlang.org/play?#code/FAFwngDgpgBAkgWwgewE4gKIA8XoPIBGAVlAMYgwC8MA3jKQK4DOIyCACqstOgJZRMAXLQC+MEaEixEuTDjQgAYgwB25XshVUYACkYs2nblD4CA-MJoiAlFQB88JAuyzCJcpOiPZLhYt4ANlAQAIYgABbaLKi8KgDmwJ7STui+6NoyzvLo-kGhETAAPt5ZrsRkFMWZqdlKquqaRbrVcrK5wWGRVSmtCm4VTS1pdWogGirWANoAuolQtTCxICYAZiGksOwBDHGxeBBjmky0wACQAPQAVJcwACJQy6gIsQIwAO7hD5+oMADCzKwEDAjDwxq8QioACYwCBcUH8Y7MWJxegAtgwuEmMHHJjhZAMALQgiwWECEwANyg0NiMAiUF4PzQvF2KhCARgKzQCAAdDBLuczqSmBSoBYYARkMgghDEhdrjAAMrQUi8FYImBMfGoDbHD4mWD-AxAkFY9WkCHi2C8HpUjlcBAAGne4V4pEizzi4QoxL+CoVToAUv6YBDoUG8AA5DmBAROlb1Q4qJhO0MwSEMioBMAwkJMYXQ5DlchMXn8s7Wtr2sVDWqyq43JVkVXqyECMasxO674GtHGzGmY7mrQ++ayW2sJ0fV3u5ley2+4NBlNQmDhqNqoLJjkJ8Zb1Pp1CZ7OhPO2wvuEAlvkC06jhQAFWQ1Z6w2AEmAd-SS1W6022xZJynDo3CdmKWw7HsBy7tYlhnKcKAsKQebgSywgAOQISASFMAAtPogI4bCxgDmhDpwaSoSHjodBcMgIDCBC2Y2MIOhwacxQ0Gxpz3KQAQhKgYTjCxra8QxKhgLYlAOOSyC8JCADcXF4GoorCKorZqioVKKacukSLp7GAQZykbCxtH0SG4mSQ4RjPMKAA8MlyXYOkGTxfECYmwlkAEYkSfYMBOQpbH6ac1hnCIZHwcgiF5sIICoAwUBvokIkebApBHBQED-rEwgobEcwLBpIQEtluUqEAA)). The new version does not have an error ([link to playground](https://www.typescriptlang.org/play?#code/FAFwngDgpgBAkgWwgewE4gKIA8XoPIBGAVlAMYgwC8MA3jKQK4DOIyCACqstOgJZRMAXLQC+MEaEixEuTDjQgAYgwB25XshVUYACkYs2nblD4CA-MJoiAlFQB88JAuyzCJcpOiPZLhYt4ANlAQAIYgABbaLKi8KgDmwJ7STui+6NoyzvLo-kGhETAAPt5ZrsRkFMWZqdlKquqaRbrVcrK5wWGRVSmtCm4VTS1pdWogGirWANoAuolQtTCxICYAZiGksOwBDHGxeBBjmky0wACQAPQAVJcwACJQy6gIsQIwAO7hD5+oMADCzKwEDAjDwxq8QioACYwCBcUH8Y7MWJxegAtgwuEmMHHJjhZAMALQgiwWECEwANyg0NiMAiUF4PzQvF2KhCARgKzQCAAdDBLuczqSmBSoBYYARkMgghDEhdrjAAMrQUi8FYImBMfGoDbHD4mWD-AxAkFY9WkCHi2C8HpUjlcBAAGne4V4pEizzi4QoxL+CoVToAUv6YBDoUG8AA5DmBAROlb1Q4qJhO0MwSEMioBMAwkJMYXQ5DlchMXn8s7Wtr2sVDWqyq43JVkVXqyECMasxO674GtHGzGmY7mrQ++ayW2sJ0fV3u5ley2+4NBlNQmDhqNqoLJjkJ8Zb1Pp1CZ7OhPO2wvuEAlvkC06jhQAFWQ1Z6w2AEmAd-SS1W6022xZJynDo3CdmKWw7HsBy7tYlhnKcKAsKQebgSywgAOQISASFMAAtPogI4bCxgDmhDpwaSoSHjodBcMgFAiJYMC0SAwgQtmNjCDocGnMUNDcac9ykAEISoGE4yca2QmsSoYC2JQDjksgvCQgA3PxeBqKKwiqK2aoqFSamnEZEhGTxgGmRpGyccx0myfYwL2rwwoADyKcpdiGaZgnCaJiYSWQAS2XJClKap3Emac1hnCIZHwcgiF5sIICoAwUBvokkk+bApBHBQED-rEwgobEcwLLpIQEnlBUqEAA)).

Thanks for taking a look! cc @jonathantneal, any chance this could make a quick patch release?