### PR TITLE
Switching to postcss-value-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "postcss-values-parser": "^6"
+    "postcss-value-parser": "^4.2.0"
   },
   "peerDependencies": {
     "postcss": "^8.3"

--- a/src/lib/get-custom-properties-from-imports.js
+++ b/src/lib/get-custom-properties-from-imports.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import { parse as postcssParse } from 'postcss';
-import { parse } from 'postcss-values-parser';
+import { parse } from 'postcss';
+import valuesParser from 'postcss-value-parser';
 import getCustomPropertiesFromRoot from './get-custom-properties-from-root';
 
 /* Get Custom Properties from CSS File
@@ -9,7 +9,7 @@ import getCustomPropertiesFromRoot from './get-custom-properties-from-root';
 
 async function getCustomPropertiesFromCSSFile(from) {
 	const css = await readFile(from);
-	const root = postcssParse(css, { from });
+	const root = parse(css, { from });
 
 	return getCustomPropertiesFromRoot(root, { preserve: true });
 }
@@ -25,7 +25,7 @@ function getCustomPropertiesFromObject(object) {
 	);
 
 	for (const key in customProperties) {
-		customProperties[key] = parse(String(customProperties[key])).nodes;
+		customProperties[key] = valuesParser(String(customProperties[key]));
 	}
 
 	return customProperties;

--- a/src/lib/get-custom-properties-from-root.js
+++ b/src/lib/get-custom-properties-from-root.js
@@ -1,4 +1,4 @@
-import { parse } from 'postcss-values-parser';
+import valuesParser from 'postcss-value-parser';
 import { isBlockIgnored } from './is-ignored';
 
 // return custom selectors from the css root, conditionally removing them
@@ -22,7 +22,7 @@ export default function getCustomPropertiesFromRoot(root, opts) {
 					const { prop } = decl;
 
 					// write the parsed value to the custom property
-					customPropertiesObject[prop] = parse(decl.value).nodes;
+					customPropertiesObject[prop] = valuesParser(decl.value);
 
 					// conditionally remove the custom property declaration
 					if (!opts.preserve) {

--- a/src/lib/transform-properties.js
+++ b/src/lib/transform-properties.js
@@ -1,4 +1,4 @@
-import { parse } from 'postcss-values-parser';
+import valuesParser from 'postcss-value-parser';
 import transformValueAST from './transform-value-ast';
 import { isRuleIgnored } from './is-ignored';
 
@@ -6,16 +6,16 @@ import { isRuleIgnored } from './is-ignored';
 export default (decl, customProperties, opts) => {
 	if (isTransformableDecl(decl) && !isRuleIgnored(decl)) {
 		const originalValue = decl.value;
-		const valueAST = parse(originalValue);
-		let value = String(transformValueAST(valueAST, customProperties));
+		const valueAST = valuesParser(originalValue);
+		let value = transformValueAST(valueAST, customProperties);
 
 		// protect against circular references
 		const valueSet = new Set();
 
 		while (customPropertiesRegExp.test(value) && !valueSet.has(value)) {
 			valueSet.add(value);
-			const parsedValueAST = parse(valueAST);
-			value = String(transformValueAST(parsedValueAST, customProperties));
+			const parsedValueAST = valuesParser(value);
+			value = transformValueAST(parsedValueAST, customProperties);
 		}
 
 		// conditionally transform values that have changed

--- a/src/lib/write-custom-properties-to-exports.js
+++ b/src/lib/write-custom-properties-to-exports.js
@@ -130,9 +130,7 @@ export default function writeCustomPropertiesToExports(customProperties, destina
 const defaultCustomPropertiesToJSON = customProperties => {
 	return Object.keys(customProperties).reduce((customPropertiesJSON, key) => {
 		const valueNodes = customProperties[key];
-		customPropertiesJSON[key] = valueNodes.map((propertyObject) => {
-			return propertyObject.toString();
-		}).join(' ');
+		customPropertiesJSON[key] = valueNodes.toString();
 
 		return customPropertiesJSON;
 	}, {});

--- a/test/export-properties.css
+++ b/test/export-properties.css
@@ -10,6 +10,6 @@
 	--margin: 0 10px 20px 30px;
 	--shadow-color: rgb(255,0,0);
 	--shadow: 0 6px 14px 0 color(var(--shadow-color) a(.15));
-	--font-family: "Open Sans" , sans-serif;
+	--font-family: "Open Sans", sans-serif;
 	--theme-color: #053;
 }

--- a/test/export-properties.js
+++ b/test/export-properties.js
@@ -11,7 +11,7 @@ module.exports = {
 		'--margin': '0 10px 20px 30px',
 		'--shadow-color': 'rgb(255,0,0)',
 		'--shadow': '0 6px 14px 0 color(var(--shadow-color) a(.15))',
-		'--font-family': '"Open Sans" , sans-serif',
+		'--font-family': '"Open Sans", sans-serif',
 		'--theme-color': '#053'
 	}
 };

--- a/test/export-properties.json
+++ b/test/export-properties.json
@@ -11,7 +11,7 @@
     "--margin": "0 10px 20px 30px",
     "--shadow-color": "rgb(255,0,0)",
     "--shadow": "0 6px 14px 0 color(var(--shadow-color) a(.15))",
-    "--font-family": "\"Open Sans\" , sans-serif",
+    "--font-family": "\"Open Sans\", sans-serif",
     "--theme-color": "#053"
   }
 }

--- a/test/export-properties.mjs
+++ b/test/export-properties.mjs
@@ -10,6 +10,6 @@ export const customProperties = {
 	'--margin': '0 10px 20px 30px',
 	'--shadow-color': 'rgb(255,0,0)',
 	'--shadow': '0 6px 14px 0 color(var(--shadow-color) a(.15))',
-	'--font-family': '"Open Sans" , sans-serif',
+	'--font-family': '"Open Sans", sans-serif',
 	'--theme-color': '#053'
 };

--- a/test/export-properties.scss
+++ b/test/export-properties.scss
@@ -9,5 +9,5 @@ $circular-2: var(--circular);
 $margin: 0 10px 20px 30px;
 $shadow-color: rgb(255,0,0);
 $shadow: 0 6px 14px 0 color(var(--shadow-color) a(.15));
-$font-family: "Open Sans" , sans-serif;
+$font-family: "Open Sans", sans-serif;
 $theme-color: #053;


### PR DESCRIPTION
This is a PR to swap `postcss-values-parser` to `postcss-value-parser` given this issue: https://github.com/csstools/postcss-preset-env/issues/228

We've identified that prototype modification leads to unexpected behavior whenever multiple versions are running. This can happen due to different versions or due to NPM not deduping.